### PR TITLE
Added unzip

### DIFF
--- a/cygwin_ansible.ps1
+++ b/cygwin_ansible.ps1
@@ -95,6 +95,7 @@ $cyg_packages=@(
 "python-paramiko           ",
 "python-six                ",
 "rsync                     ",
+"unzip                     ", 
 "wget                      ",
 "which                     ",
 "windows-default-manifest  "


### PR DESCRIPTION
The package validation for the selenium webdriver jar uses unzip to test validity of the archive. Added to the list to download.